### PR TITLE
Add basic unit tests and type fixes

### DIFF
--- a/src/sitebay_mcp/client.py
+++ b/src/sitebay_mcp/client.py
@@ -103,7 +103,7 @@ class SiteBayClient:
         
         return f"Validation Error: {str(error_data)}"
     
-    def _extract_field_errors(self, error_data: dict) -> dict:
+    def _extract_field_errors(self, error_data: dict) -> dict[str, str]:
         """
         Extract field-specific errors for programmatic access
         
@@ -113,7 +113,7 @@ class SiteBayClient:
         Returns:
             Dictionary mapping field names to error messages
         """
-        field_errors = {}
+        field_errors: dict[str, str] = {}
         
         if not error_data:
             return field_errors

--- a/src/sitebay_mcp/resources.py
+++ b/src/sitebay_mcp/resources.py
@@ -132,7 +132,7 @@ async def get_account_summary_resource(ctx: Context) -> str:
         regions = await client.list_regions()
         templates = await client.list_templates()
         
-        summary = {
+        summary: dict[str, Any] = {
             "account_overview": {
                 "total_sites": len(sites),
                 "total_teams": len(teams),

--- a/src/sitebay_mcp/server.py
+++ b/src/sitebay_mcp/server.py
@@ -6,7 +6,7 @@ Main server implementation that provides MCP tools for SiteBay WordPress hosting
 
 import asyncio
 import sys
-from typing import Optional
+from typing import Any, Optional
 
 from fastmcp import FastMCP
 from fastmcp.server import Context
@@ -454,7 +454,7 @@ async def sitebay_wordpress_proxy(
         await ctx.info(f"WordPress proxy request to {site_fqdn}{endpoint}")
         
         client = await initialize_client()
-        proxy_data = {
+        proxy_data: dict[str, Any] = {
             "site_fqdn": site_fqdn,
             "endpoint": endpoint,
             "method": method
@@ -499,7 +499,7 @@ async def sitebay_shopify_proxy(
         await ctx.info(f"Shopify proxy request to {shop_domain}{endpoint}")
         
         client = await initialize_client()
-        proxy_data = {
+        proxy_data: dict[str, Any] = {
             "shop_domain": shop_domain,
             "endpoint": endpoint,
             "access_token": access_token,
@@ -541,7 +541,7 @@ async def sitebay_posthog_proxy(
         await ctx.info(f"PostHog proxy request to {endpoint}")
         
         client = await initialize_client()
-        proxy_data = {
+        proxy_data: dict[str, Any] = {
             "endpoint": endpoint,
             "data": data
         }

--- a/src/sitebay_mcp/tools/operations.py
+++ b/src/sitebay_mcp/tools/operations.py
@@ -117,7 +117,7 @@ async def sitebay_site_get_events(
                 result += f"  - Description: {event.get('description')}\n"
             
             if event.get('metadata'):
-                metadata = event.get('metadata')
+                metadata = event.get('metadata') or {}
                 for key, value in metadata.items():
                     result += f"  - {key.title()}: {value}\n"
             

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,53 @@
+import os
+import pathlib
+import sys
+import types
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
+
+# Provide a minimal stub for the fastmcp package used in sitebay_mcp.__init__
+fastmcp_stub = types.ModuleType("fastmcp")
+
+class _FastMCP:
+    def __init__(self, *args, **kwargs):
+        pass
+
+fastmcp_stub.FastMCP = _FastMCP
+server_stub = types.ModuleType("fastmcp.server")
+server_stub.Context = object
+sys.modules.setdefault("fastmcp", fastmcp_stub)
+sys.modules.setdefault("fastmcp.server", server_stub)
+
+# Stub sitebay_mcp.server to avoid importing the real server during tests
+server_module = types.ModuleType("sitebay_mcp.server")
+server_module.main = lambda: None
+sys.modules.setdefault("sitebay_mcp.server", server_module)
+
+from sitebay_mcp.auth import SiteBayAuth
+from sitebay_mcp.exceptions import ConfigurationError
+
+
+def test_validate_token_length():
+    auth = SiteBayAuth(api_token="x" * 25)
+    assert auth.validate_token() is True
+
+
+def test_validate_token_short():
+    auth = SiteBayAuth(api_token="short")
+    assert auth.validate_token() is False
+
+
+def test_get_headers():
+    token = "x" * 25
+    auth = SiteBayAuth(api_token=token)
+    headers = auth.get_headers()
+    assert headers["Authorization"] == f"Bearer {token}"
+    assert headers["Content-Type"] == "application/json"
+    assert headers["Accept"] == "application/json"
+
+
+def test_missing_token_raises(monkeypatch):
+    monkeypatch.delenv("SITEBAY_API_TOKEN", raising=False)
+    with pytest.raises(ConfigurationError):
+        SiteBayAuth()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,0 +1,55 @@
+import pathlib
+import sys
+import types
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "src"))
+
+# Stub out fastmcp to satisfy sitebay_mcp package imports
+fastmcp_stub = types.ModuleType("fastmcp")
+
+class _FastMCP:
+    def __init__(self, *args, **kwargs):
+        pass
+
+fastmcp_stub.FastMCP = _FastMCP
+server_stub = types.ModuleType("fastmcp.server")
+server_stub.Context = object
+sys.modules.setdefault("fastmcp", fastmcp_stub)
+sys.modules.setdefault("fastmcp.server", server_stub)
+
+# Stub sitebay_mcp.server module
+server_module = types.ModuleType("sitebay_mcp.server")
+server_module.main = lambda: None
+sys.modules.setdefault("sitebay_mcp.server", server_module)
+
+from sitebay_mcp.client import SiteBayClient, SiteBayAuth
+
+
+def test_get_url_slash():
+    auth = SiteBayAuth(api_token="x" * 25)
+    client = SiteBayClient(auth)
+    assert client._get_url("/test") == "/f/api/v1/test"
+
+
+def test_get_url_no_slash():
+    auth = SiteBayAuth(api_token="x" * 25)
+    client = SiteBayClient(auth)
+    assert client._get_url("test") == "/f/api/v1/test"
+
+
+def test_format_validation_error_basic():
+    auth = SiteBayAuth(api_token="x" * 25)
+    client = SiteBayClient(auth)
+    data = {"detail": [{"loc": ["field"], "msg": "required"}]}
+    msg = client._format_validation_error(data)
+    assert "field" in msg
+    assert "required" in msg
+
+
+def test_extract_field_errors():
+    auth = SiteBayAuth(api_token="x" * 25)
+    client = SiteBayClient(auth)
+    data = {"detail": [{"loc": ["field"], "msg": "required"}]}
+    errors = client._extract_field_errors(data)
+    assert errors == {"field": "required"}


### PR DESCRIPTION
## Summary
- fix typing in `_extract_field_errors` and proxy helper functions
- ensure operations handles missing metadata
- annotate summary variable in resources
- add basic unit tests for auth and client modules

## Testing
- `uv run pytest tests/unit`
- `mypy --ignore-missing-imports src`

------
https://chatgpt.com/codex/tasks/task_e_68610eb7348883229090071c66952fb0